### PR TITLE
fix: restore transition links on target clips when loading from JSON

### DIFF
--- a/packages/video/src/studio/timeline-model.ts
+++ b/packages/video/src/studio/timeline-model.ts
@@ -913,6 +913,37 @@ export class TimelineModel {
       }
     }
 
+    // Restore transition links on target clips
+    // Transition clips store fromClipId/toClipId, but the preview engine
+    // expects clip.transition on the actual video/image clips
+    for (const clip of this.clips) {
+      if (clip instanceof Transition) {
+        const transitionMeta = {
+          name: clip.transitionEffect.key,
+          key: clip.transitionEffect.key,
+          duration: clip.duration,
+          fromClipId: clip.fromClipId,
+          toClipId: clip.toClipId,
+          start: clip.display.from,
+          end: clip.display.to,
+        };
+
+        if (clip.fromClipId) {
+          const fromClip = this.getClipById(clip.fromClipId);
+          if (fromClip) {
+            (fromClip as any).transition = { ...transitionMeta };
+          }
+        }
+
+        if (clip.toClipId) {
+          const toClip = this.getClipById(clip.toClipId);
+          if (toClip) {
+            (toClip as any).transition = { ...transitionMeta };
+          }
+        }
+      }
+    }
+
     // Recalculate duration once
     await this.recalculateMaxDuration();
 


### PR DESCRIPTION
## Summary

When loading a project with transitions, the Transition clips were loaded correctly but the `transition` property was not restored on the linked video/image clips (fromClip, toClip).

The preview engine checks `clip.transition` on video/image clips to render transition effects. Without this property, transitions appeared in the timeline but not in the preview.

## Changes

This fix adds a post-processing step in `loadFromJSON()` that:
1. Iterates through loaded Transition clips
2. Builds the `transitionMeta` object with `name`, `key`, `duration`, `fromClipId`, `toClipId`, `start`, `end`
3. Sets `clip.transition` on both the `fromClip` and `toClip`

This matches the behavior of `addTransition()` when creating transitions interactively.

## Test plan

- [ ] Load a project that has transitions between clips
- [ ] Verify transitions appear in the preview (not just timeline)
- [ ] Verify transitions render correctly during playback