### PR TITLE
feat: OPFS persistence for uploads panel

### DIFF
--- a/editor/src/components/editor/media-panel/panel/uploads.tsx
+++ b/editor/src/components/editor/media-panel/panel/uploads.tsx
@@ -1,16 +1,35 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useStudioStore } from '@/stores/studio-store';
-import { Image, Video, Log } from '@designcombo/video';
-import { Upload, Film } from 'lucide-react';
-import { uploadFile } from '@/lib/upload-utils';
+import {
+  Image,
+  Video,
+  Audio,
+  Log,
+  clipToJSON,
+  type IClip as StudioClip,
+} from '@designcombo/video';
+import {
+  Upload,
+  Film,
+  Search,
+  X,
+  HardDrive,
+  Trash2,
+  Music,
+} from 'lucide-react';
+import {
+  storageService,
+  type StorageStats,
+} from '@/lib/storage/storage-service';
+import type { MediaFile, MediaType } from '@/types/media';
 
 interface VisualAsset {
   id: string;
-  type: 'image' | 'video';
+  type: MediaType;
   src: string;
   name: string;
   preview?: string;
@@ -21,54 +40,252 @@ interface VisualAsset {
 }
 
 const STORAGE_KEY = 'designcombo_uploads';
+const PROJECT_ID = 'local-uploads';
+
+// Detect file type from MIME type and extension
+function detectFileType(file: File): MediaType {
+  const mime = file.type.toLowerCase();
+  const ext = file.name.split('.').pop()?.toLowerCase() || '';
+
+  if (
+    mime.startsWith('audio/') ||
+    ['mp3', 'wav', 'ogg', 'flac', 'aac', 'm4a'].includes(ext)
+  ) {
+    return 'audio';
+  }
+  if (
+    mime.startsWith('video/') ||
+    ['mp4', 'webm', 'mov', 'avi', 'mkv'].includes(ext)
+  ) {
+    return 'video';
+  }
+  return 'image';
+}
+
+// Replace old blob URLs with new ones in serialized clips
+function replaceUrlsInClips<T>(
+  clips: T[],
+  urlMapping: Record<string, string>
+): T[] {
+  const json = JSON.stringify(clips);
+  let updated = json;
+  for (const [oldUrl, newUrl] of Object.entries(urlMapping)) {
+    updated = updated.split(oldUrl).join(newUrl);
+  }
+  return JSON.parse(updated);
+}
+
+// Asset card component
+function AssetCard({
+  asset,
+  onAdd,
+  onDelete,
+}: {
+  asset: VisualAsset;
+  onAdd: (asset: VisualAsset) => void;
+  onDelete: (id: string) => void;
+}) {
+  return (
+    <div
+      className="group relative aspect-square rounded-md overflow-hidden bg-secondary/50 cursor-pointer border border-transparent hover:border-primary/50 transition-all"
+      onClick={() => onAdd(asset)}
+    >
+      {asset.type === 'image' ? (
+        <img
+          src={asset.src}
+          alt={asset.name}
+          className="w-full h-full object-cover"
+        />
+      ) : asset.type === 'audio' ? (
+        <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-purple-500/20 to-pink-500/20">
+          <Music className="text-white/70 drop-shadow-md" size={24} />
+        </div>
+      ) : (
+        <div className="w-full h-full flex items-center justify-center bg-black/20">
+          <video
+            src={asset.src}
+            className="w-full h-full object-cover pointer-events-none"
+          />
+          <Film className="absolute text-white/70 drop-shadow-md" size={24} />
+        </div>
+      )}
+
+      {/* Delete button */}
+      <button
+        type="button"
+        className="absolute top-1 right-1 p-1 rounded bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity hover:bg-red-500/80"
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete(asset.id);
+        }}
+      >
+        <Trash2 size={12} className="text-white" />
+      </button>
+
+      {/* Name overlay */}
+      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent p-2 opacity-0 group-hover:opacity-100 transition-opacity">
+        <p className="text-[10px] text-white truncate font-medium">
+          {asset.name}
+        </p>
+      </div>
+    </div>
+  );
+}
 
 export default function PanelUploads() {
   const { studio } = useStudioStore();
   const [searchQuery, setSearchQuery] = useState('');
   const [uploads, setUploads] = useState<VisualAsset[]>([]);
   const [isUploading, setIsUploading] = useState(false);
+  const [storageStats, setStorageStats] = useState<StorageStats | null>(null);
+  const [isLoaded, setIsLoaded] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const [isLoaded, setIsLoaded] = useState(false);
-
-  // Load uploads from local storage on mount
-  useEffect(() => {
-    try {
-      const stored = localStorage.getItem(STORAGE_KEY);
-      if (stored) {
-        setUploads(JSON.parse(stored));
-      }
-    } catch (e) {
-      console.error('Failed to load uploads', e);
-    } finally {
-      setIsLoaded(true);
-    }
+  // Load storage stats
+  const loadStorageStats = useCallback(async () => {
+    const stats = await storageService.getStorageStats();
+    setStorageStats(stats);
   }, []);
 
-  // Save uploads to local storage whenever they change
+  // Recover uploads from OPFS on mount
   useEffect(() => {
-    if (!isLoaded) return;
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(uploads));
-  }, [uploads, isLoaded]);
+    const recoverFromOPFS = async () => {
+      try {
+        if (!storageService.isOPFSSupported()) {
+          // Fall back to localStorage only (won't persist blobs)
+          const stored = localStorage.getItem(STORAGE_KEY);
+          if (stored) {
+            setUploads(JSON.parse(stored));
+          }
+          setIsLoaded(true);
+          return;
+        }
 
+        // Load files from OPFS
+        const opfsFiles = await storageService.loadAllMediaFiles({
+          projectId: PROJECT_ID,
+        });
+
+        if (opfsFiles.length === 0) {
+          // No OPFS files, try localStorage for backwards compatibility
+          const stored = localStorage.getItem(STORAGE_KEY);
+          if (stored) {
+            setUploads(JSON.parse(stored));
+          }
+          setIsLoaded(true);
+          await loadStorageStats();
+          return;
+        }
+
+        // Load old localStorage entries for URL mapping
+        const oldEntries: VisualAsset[] = JSON.parse(
+          localStorage.getItem(STORAGE_KEY) || '[]'
+        );
+        const urlMapping: Record<string, string> = {};
+
+        // Generate new blob URLs from OPFS files
+        const recoveredAssets: VisualAsset[] = opfsFiles.map((file) => {
+          const newBlobUrl = file.url || URL.createObjectURL(file.file);
+
+          // Find matching old entry by ID or name to map URLs
+          const oldEntry = oldEntries.find(
+            (e) => e.id === file.id || e.name === file.name
+          );
+          if (oldEntry?.src && oldEntry.src !== newBlobUrl) {
+            urlMapping[oldEntry.src] = newBlobUrl;
+          }
+
+          return {
+            id: file.id,
+            name: file.name,
+            src: newBlobUrl,
+            type: file.type,
+            width: file.width,
+            height: file.height,
+            duration: file.duration,
+          };
+        });
+
+        // Update timeline clips with new blob URLs if needed
+        if (Object.keys(urlMapping).length > 0 && studio) {
+          try {
+            // Serialize current clips
+            const serializedClips = studio.clips.map((clip) =>
+              clipToJSON(clip as unknown as StudioClip)
+            );
+            // Replace old URLs with new blob URLs
+            const updatedClips = replaceUrlsInClips(
+              serializedClips,
+              urlMapping
+            );
+            // Reload with updated URLs
+            await studio.loadFromJSON({ clips: updatedClips });
+          } catch (error) {
+            Log.warn('Failed to update timeline URLs:', error);
+          }
+        }
+
+        setUploads(recoveredAssets);
+        // Update localStorage with new URLs
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(recoveredAssets));
+        await loadStorageStats();
+      } catch (error) {
+        console.error('Failed to recover uploads from OPFS:', error);
+        // Fall back to localStorage
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (stored) {
+          setUploads(JSON.parse(stored));
+        }
+      } finally {
+        setIsLoaded(true);
+      }
+    };
+
+    recoverFromOPFS();
+  }, [studio, loadStorageStats]);
+
+  // Handle file upload
   const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
 
     setIsUploading(true);
+    const newAssets: VisualAsset[] = [];
+
     try {
-      const result = await uploadFile(file);
-      const type = file.type.startsWith('image/') ? 'image' : 'video';
+      for (const file of Array.from(files)) {
+        const blobUrl = URL.createObjectURL(file);
+        const id = crypto.randomUUID();
+        const type = detectFileType(file);
 
-      const newAsset: VisualAsset = {
-        id: crypto.randomUUID(),
-        type,
-        src: result.url,
-        name: result.fileName,
-        size: file.size,
-      };
+        // Save to OPFS if supported
+        if (storageService.isOPFSSupported()) {
+          const mediaFile: MediaFile = {
+            id,
+            file,
+            name: file.name,
+            type,
+            url: blobUrl,
+          };
+          await storageService.saveMediaFile({
+            projectId: PROJECT_ID,
+            mediaItem: mediaFile,
+          });
+        }
 
-      setUploads((prev) => [newAsset, ...prev]);
+        newAssets.push({
+          id,
+          name: file.name,
+          src: blobUrl,
+          type,
+          size: file.size,
+        });
+      }
+
+      const updated = [...newAssets, ...uploads];
+      setUploads(updated);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+      await loadStorageStats();
     } catch (error) {
       console.error('Upload failed:', error);
     } finally {
@@ -79,6 +296,26 @@ export default function PanelUploads() {
     }
   };
 
+  // Handle delete
+  const handleDelete = async (id: string) => {
+    try {
+      if (storageService.isOPFSSupported()) {
+        await storageService.deleteMediaFile({
+          projectId: PROJECT_ID,
+          id,
+        });
+      }
+
+      const updated = uploads.filter((a) => a.id !== id);
+      setUploads(updated);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+      await loadStorageStats();
+    } catch (error) {
+      console.error('Failed to delete upload:', error);
+    }
+  };
+
+  // Add item to canvas
   const addItemToCanvas = async (asset: VisualAsset) => {
     if (!studio) return;
 
@@ -87,15 +324,14 @@ export default function PanelUploads() {
         const imageClip = await Image.fromUrl(asset.src + '?v=' + Date.now());
         imageClip.display = { from: 0, to: 5 * 1e6 };
         imageClip.duration = 5 * 1e6;
-
-        // Scale to fit and center in scene (1080x1920)
         await imageClip.scaleToFit(1080, 1920);
         imageClip.centerInScene(1080, 1920);
-
         await studio.addClip(imageClip);
+      } else if (asset.type === 'audio') {
+        const audioClip = await Audio.fromUrl(asset.src);
+        await studio.addClip(audioClip);
       } else {
         const videoClip = await Video.fromUrl(asset.src);
-        // Scale to fit and center in scene (1080x1920)
         await videoClip.scaleToFit(1080, 1920);
         videoClip.centerInScene(1080, 1920);
         await studio.addClip(videoClip);
@@ -105,78 +341,121 @@ export default function PanelUploads() {
     }
   };
 
-  const filteredAssets = uploads.filter((asset) => {
-    const matchesSearch = asset.name
-      .toLowerCase()
-      .includes(searchQuery.toLowerCase());
-    return matchesSearch;
-  });
+  // Filter assets by search query
+  const filteredAssets = uploads.filter((asset) =>
+    asset.name.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  if (!isLoaded) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <span className="text-sm text-muted-foreground">Loading...</span>
+      </div>
+    );
+  }
 
   return (
     <div className="h-full flex flex-col">
+      {/* Upload button */}
       <div className="flex items-center w-full p-4">
         <Button
+          type="button"
           className="w-full h-9"
           onClick={() => fileInputRef.current?.click()}
           disabled={isUploading}
         >
           <Upload size={14} />
           <span className="text-xs font-medium">
-            {isUploading ? 'Uploading...' : 'Upload'}
+            {isUploading ? 'Uploading...' : 'Upload files'}
           </span>
         </Button>
         <input
           type="file"
           ref={fileInputRef}
           className="hidden"
-          accept="image/*,video/*"
+          accept="image/*,video/*,audio/*"
+          multiple
           onChange={handleFileUpload}
         />
       </div>
 
+      {/* Search input */}
+      {uploads.length > 0 && (
+        <div className="relative px-4 mb-2">
+          <Search className="absolute left-6 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+          <input
+            type="text"
+            placeholder="Search uploads..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full pl-8 pr-8 py-1.5 text-sm bg-secondary rounded-md border-none outline-none focus:ring-1 focus:ring-primary/50"
+          />
+          {searchQuery && (
+            <button
+              type="button"
+              onClick={() => setSearchQuery('')}
+              className="absolute right-6 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Assets grid */}
       <ScrollArea className="flex-1 px-4">
         {filteredAssets.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-10 text-muted-foreground gap-2">
             <Upload size={32} className="opacity-50" />
-            <span className="text-sm">No uploads found</span>
+            <span className="text-sm">
+              {uploads.length === 0 ? 'No uploads yet' : 'No matches found'}
+            </span>
           </div>
         ) : (
-          <div className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-2">
-            {filteredAssets.map((asset) => (
-              <div
-                key={asset.id}
-                className="group relative aspect-square rounded-md overflow-hidden bg-secondary/50 cursor-pointer border border-transparent hover:border-primary/50 transition-all"
-                onClick={() => addItemToCanvas(asset)}
-              >
-                {asset.type === 'image' ? (
-                  <img
-                    src={asset.src}
-                    alt={asset.name}
-                    className="w-full h-full object-cover"
-                  />
-                ) : (
-                  <div className="w-full h-full flex items-center justify-center bg-black/20">
-                    <video
-                      src={asset.src}
-                      className="w-full h-full object-cover pointer-events-none"
-                    />
-                    <Film
-                      className="absolute text-white/70 drop-shadow-md"
-                      size={24}
-                    />
-                  </div>
-                )}
-
-                <div className="absolute inset-x-0 bottom-0 bg-linear-to-t from-black/80 to-transparent p-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                  <p className="text-[10px] text-white truncate font-medium">
-                    {asset.name}
-                  </p>
-                </div>
-              </div>
-            ))}
-          </div>
+          <>
+            <div className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-2">
+              {filteredAssets.map((asset) => (
+                <AssetCard
+                  key={asset.id}
+                  asset={asset}
+                  onAdd={addItemToCanvas}
+                  onDelete={handleDelete}
+                />
+              ))}
+            </div>
+            <p className="text-[10px] text-muted-foreground text-center mt-3 mb-2">
+              {uploads.length} upload{uploads.length !== 1 ? 's' : ''}
+              {searchQuery && ` (showing ${filteredAssets.length})`}
+            </p>
+          </>
         )}
       </ScrollArea>
+
+      {/* Storage stats footer */}
+      {storageStats && (
+        <div className="px-4 py-3 border-t border-border/50">
+          <div className="flex items-center justify-between text-[10px] text-muted-foreground mb-1.5">
+            <span className="flex items-center gap-1">
+              <HardDrive size={10} />
+              Local Storage
+            </span>
+            <span>
+              {storageStats.usedMB} MB /{' '}
+              {storageStats.quotaMB > 1000
+                ? `${(storageStats.quotaMB / 1024).toFixed(1)} GB`
+                : `${storageStats.quotaMB} MB`}
+            </span>
+          </div>
+          <div className="h-1.5 bg-secondary rounded-full overflow-hidden">
+            <div
+              className="h-full bg-primary/70 rounded-full transition-all"
+              style={{
+                width: `${Math.min(storageStats.percentUsed, 100)}%`,
+              }}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

This PR adds OPFS (Origin Private File System) persistence to the uploads panel, enabling uploaded files to survive page reloads.

### Features
- **OPFS persistence**: Store uploaded file binaries in OPFS for persistence across page reloads
- **Blob URL recovery**: Regenerate blob URLs on mount from stored file binaries
- **Timeline sync**: Update timeline clip sources with new blob URLs after recovery
- **Search UI**: Working search input with filtering and clear button
- **Delete functionality**: Remove uploaded files from OPFS and state
- **Audio file support**: Support for mp3, wav, ogg, flac, aac, m4a files
- **Storage stats**: Display used/quota space with progress bar
- **Multiple uploads**: Support selecting multiple files at once

### Technical Details
- Uses existing `storageService` with a fixed project scope `'local-uploads'`
- Adds `getStorageStats()` method to `StorageService` using browser's StorageManager API
- Gracefully falls back to localStorage-only mode when OPFS is not supported
- Extracts reusable `AssetCard` component

### Before/After

**Before**: Uploads stored only in localStorage (blob URLs break on reload)
**After**: File binaries stored in OPFS, blob URLs regenerated on mount

## Test plan
- [ ] Upload image/video/audio files
- [ ] Verify search filters assets in real-time
- [ ] Hover over asset and click trash to delete
- [ ] Refresh page - uploads should persist and reappear
- [ ] Add uploaded file to timeline, refresh, verify timeline still works
- [ ] Check storage stats bar at bottom updates after uploads
- [ ] Test in browser without OPFS support (graceful fallback)